### PR TITLE
Added Mode 01 functionality with supporting headers and source files

### DIFF
--- a/30_Code/services/Mode_01/include/PID_values.h
+++ b/30_Code/services/Mode_01/include/PID_values.h
@@ -1,0 +1,30 @@
+#ifndef PID_VALUES_H
+#define PID_VALUES_H
+
+// PID Value Macros
+#define PID_VAL_SUPPORTED_00             0x00000030  // PID_SUPPORTED_00 (supports 0x04 and 0x05)
+#define PID_VAL_ENGINE_LOAD_04           75          // PID_ENGINE_LOAD_04
+#define PID_VAL_COOLANT_TEMP_05          90          // PID_COOLANT_TEMP_05
+
+#define PID_VAL_SUPPORTED_20             0x00002A00  // PID_SUPPORTED_20 (supports 0x2D and 0x2F)
+#define PID_VAL_FUEL_RAIL_PRESSURE_2D    10          // PID_FUEL_RAIL_PRESSURE_2D
+#define PID_VAL_FUEL_LEVEL_2F            50          // PID_FUEL_LEVEL_2F
+
+#define PID_VAL_SUPPORTED_40             0x0C000000  // PID_SUPPORTED_40 (supports 0x45 and 0x46)
+#define PID_VAL_AMBIENT_TEMP_45          50          // PID_AMBIENT_TEMP_45
+#define PID_VAL_ABS_BARO_PRESSURE_46     20          // PID_ABS_BARO_PRESSURE_46
+
+#define PID_VAL_SUPPORTED_60             0x06000000  // PID_SUPPORTED_60 (supports 0x62 and 0x63)
+#define PID_VAL_COMMANDED_EQUIV_RATIO_62 70          // PID_COMMANDED_EQUIV_RATIO_62
+#define PID_VAL_ENGINE_REFERENCE_TORQUE_63 160        // PID_ENGINE_REFERENCE_TORQUE_63
+
+#define PID_VAL_SUPPORTED_80             0x00000121  // PID_SUPPORTED_80 (supports 0x80, 0x85, and 0x8E)
+#define PID_VAL_THROTTLE_POS_85         35          // PID_THROTTLE_POS_85
+#define PID_VAL_ENGINE_FRICTION_PERCENT_8E 5          // PID_ENGINE_FRICTION_PERCENT_8E
+
+#define PID_VAL_SUPPORTED_A0             0x00000005  // PID_SUPPORTED_A0 (supports 0xA0 and 0xA2)
+#define PID_VAL_ENGINE_PERCENT_TORQUE_A2 3           // PID_ENGINE_PERCENT_TORQUE_A2
+
+#define PID_VAL_SUPPORTED_C0             0x00000000  // PID_SUPPORTED_C0 (no specific PIDs supported)
+
+#endif // PID_VALUES_H

--- a/30_Code/services/Mode_01/include/PID_values.h
+++ b/30_Code/services/Mode_01/include/PID_values.h
@@ -1,3 +1,4 @@
+//PID_Values.h   
 #ifndef PID_VALUES_H
 #define PID_VALUES_H
 
@@ -6,25 +7,29 @@
 #define PID_VAL_ENGINE_LOAD_04           75          // PID_ENGINE_LOAD_04
 #define PID_VAL_COOLANT_TEMP_05          90          // PID_COOLANT_TEMP_05
 
+#define PID_VAL_ENGINE_RPM_0C            0x2EE0      // 3000 RPM
 #define PID_VAL_SUPPORTED_20             0x00002A00  // PID_SUPPORTED_20 (supports 0x2D and 0x2F)
-#define PID_VAL_FUEL_RAIL_PRESSURE_2D    10          // PID_FUEL_RAIL_PRESSURE_2D
+#define PID_VAL_FUEL_RAIL_PRESSURE_22    0x3A80     // 150000 kPa
+#define PID_VAL_COMMANDED_EGR_2C          153     // ~60%
+#define PID_VAL_EGR_Error_2D             10          // PID_FUEL_RAIL_PRESSURE_2D
 #define PID_VAL_FUEL_LEVEL_2F            50          // PID_FUEL_LEVEL_2F
 
+#define PID_VAL_DISTANCE_SINCE_DTC_31    0x03E8     // 1000 km
 #define PID_VAL_SUPPORTED_40             0x0C000000  // PID_SUPPORTED_40 (supports 0x45 and 0x46)
 #define PID_VAL_AMBIENT_TEMP_45          50          // PID_AMBIENT_TEMP_45
 #define PID_VAL_ABS_BARO_PRESSURE_46     20          // PID_ABS_BARO_PRESSURE_46
 
 #define PID_VAL_SUPPORTED_60             0x06000000  // PID_SUPPORTED_60 (supports 0x62 and 0x63)
-#define PID_VAL_COMMANDED_EQUIV_RATIO_62 70          // PID_COMMANDED_EQUIV_RATIO_62
+#define PID_VAL_Actual_engine_percent_torque_62 70          // PID_COMMANDED_EQUIV_RATIO_62
 #define PID_VAL_ENGINE_REFERENCE_TORQUE_63 160        // PID_ENGINE_REFERENCE_TORQUE_63
 
 #define PID_VAL_SUPPORTED_80             0x00000121  // PID_SUPPORTED_80 (supports 0x80, 0x85, and 0x8E)
-#define PID_VAL_THROTTLE_POS_85         35          // PID_THROTTLE_POS_85
+#define PID_VAL_NOx_reagent_system_85         35          // PID_THROTTLE_POS_85
 #define PID_VAL_ENGINE_FRICTION_PERCENT_8E 5          // PID_ENGINE_FRICTION_PERCENT_8E
 
-#define PID_VAL_SUPPORTED_A0             0x00000005  // PID_SUPPORTED_A0 (supports 0xA0 and 0xA2)
-#define PID_VAL_ENGINE_PERCENT_TORQUE_A2 3           // PID_ENGINE_PERCENT_TORQUE_A2
+#define PID_VAL_SUPPORTED_A0              0x00000030  // Supports PIDs 0xA4 and 0xA5
+#define PID_VAL_Transmission_Actual_Gear_A4       10   //PID_Transmission_Actual_Gear_A4 
+#define PID_VAL_Commanded_Diesel_Exhaust_Fluid_Dosing_A5    11     //PID_Commanded_Diesel_Exhaust_Fluid_Dosing_A5   
 
-#define PID_VAL_SUPPORTED_C0             0x00000000  // PID_SUPPORTED_C0 (no specific PIDs supported)
 
 #endif // PID_VALUES_H

--- a/30_Code/services/Mode_01/include/mode_01.h
+++ b/30_Code/services/Mode_01/include/mode_01.h
@@ -1,0 +1,10 @@
+// Mode_01.h
+#ifndef MODE_01_H
+#define MODE_01_H
+
+#include "types.h"
+
+// Expose the request handler function
+void Mode_01_Req_Handler(CanMsg_t OBDRequest);
+
+#endif

--- a/30_Code/services/Mode_01/include/obd_PIDs.h
+++ b/30_Code/services/Mode_01/include/obd_PIDs.h
@@ -1,0 +1,54 @@
+#ifndef OBD_PIDS_H
+#define OBD_PIDS_H
+
+#include "Types.h"  // Ensure this includes typedef for uint32
+
+// Macro definitions for PID indices
+#define PID_SUPPORTED_00                   0
+#define PID_ENGINE_LOAD_04                 1
+#define PID_COOLANT_TEMP_05                2
+#define PID_SUPPORTED_20                   3
+#define PID_FUEL_RAIL_PRESSURE_2D          4
+#define PID_FUEL_LEVEL_2F                  5
+#define PID_SUPPORTED_40                   6
+#define PID_AMBIENT_TEMP_45                7
+#define PID_ABS_BARO_PRESSURE_46           8
+#define PID_SUPPORTED_60                   9
+#define PID_COMMANDED_EQUIV_RATIO_62      10
+#define PID_ENGINE_REFERENCE_TORQUE_63    11
+#define PID_SUPPORTED_80                  12
+#define PID_THROTTLE_POS_85               13
+#define PID_ENGINE_FRICTION_PERCENT_8E    14
+#define PID_SUPPORTED_A0                  15
+#define PID_ENGINE_PERCENT_TORQUE_A2      16
+#define PID_SUPPORTED_C0                  17
+
+// Total number of supported PIDs
+#define PID_COUNT 18
+
+// Enum for PID index access — improves readability
+typedef enum {
+    PID_IDX_SUPPORTED_00                = PID_SUPPORTED_00,
+    PID_IDX_ENGINE_LOAD_04             = PID_ENGINE_LOAD_04,
+    PID_IDX_COOLANT_TEMP_05            = PID_COOLANT_TEMP_05,
+    PID_IDX_SUPPORTED_20               = PID_SUPPORTED_20,
+    PID_IDX_FUEL_RAIL_PRESSURE_2D      = PID_FUEL_RAIL_PRESSURE_2D,
+    PID_IDX_FUEL_LEVEL_2F              = PID_FUEL_LEVEL_2F,
+    PID_IDX_SUPPORTED_40               = PID_SUPPORTED_40,
+    PID_IDX_AMBIENT_TEMP_45            = PID_AMBIENT_TEMP_45,
+    PID_IDX_ABS_BARO_PRESSURE_46       = PID_ABS_BARO_PRESSURE_46,
+    PID_IDX_SUPPORTED_60               = PID_SUPPORTED_60,
+    PID_IDX_COMMANDED_EQUIV_RATIO_62   = PID_COMMANDED_EQUIV_RATIO_62,
+    PID_IDX_ENGINE_REFERENCE_TORQUE_63 = PID_ENGINE_REFERENCE_TORQUE_63,
+    PID_IDX_SUPPORTED_80               = PID_SUPPORTED_80,
+    PID_IDX_THROTTLE_POS_85            = PID_THROTTLE_POS_85,
+    PID_IDX_ENGINE_FRICTION_PERCENT_8E = PID_ENGINE_FRICTION_PERCENT_8E,
+    PID_IDX_SUPPORTED_A0               = PID_SUPPORTED_A0,
+    PID_IDX_ENGINE_PERCENT_TORQUE_A2   = PID_ENGINE_PERCENT_TORQUE_A2,
+    PID_IDX_SUPPORTED_C0               = PID_SUPPORTED_C0
+} PIDIndex;
+
+// Global PID values array (defined in .c file)
+extern uint32 PIDValues[PID_COUNT];
+
+#endif // OBD_PIDS_H

--- a/30_Code/services/Mode_01/include/obd_PIDs.h
+++ b/30_Code/services/Mode_01/include/obd_PIDs.h
@@ -1,3 +1,4 @@
+//obd_PIDs.h   
 #ifndef OBD_PIDS_H
 #define OBD_PIDS_H
 
@@ -7,45 +8,57 @@
 #define PID_SUPPORTED_00                   0
 #define PID_ENGINE_LOAD_04                 1
 #define PID_COOLANT_TEMP_05                2
-#define PID_SUPPORTED_20                   3
-#define PID_FUEL_RAIL_PRESSURE_2D          4
-#define PID_FUEL_LEVEL_2F                  5
-#define PID_SUPPORTED_40                   6
-#define PID_AMBIENT_TEMP_45                7
-#define PID_ABS_BARO_PRESSURE_46           8
-#define PID_SUPPORTED_60                   9
-#define PID_COMMANDED_EQUIV_RATIO_62      10
-#define PID_ENGINE_REFERENCE_TORQUE_63    11
-#define PID_SUPPORTED_80                  12
-#define PID_THROTTLE_POS_85               13
-#define PID_ENGINE_FRICTION_PERCENT_8E    14
-#define PID_SUPPORTED_A0                  15
-#define PID_ENGINE_PERCENT_TORQUE_A2      16
-#define PID_SUPPORTED_C0                  17
+#define PID_ENGINE_RPM_0C                  3
+#define PID_SUPPORTED_20                   4
+#define	 PID_FUEL_RAIL_PRESSURE_22         5
+#define PID_COMMANDED_EGR_2C              6
+#define PID_EGR_Error_2D                   7
+#define PID_FUEL_LEVEL_2F                  8
+#define PID_DISTANCE_SINCE_DTC_31          9
+#define PID_SUPPORTED_40                   10
+#define PID_AMBIENT_TEMP_45                11
+#define PID_ABS_BARO_PRESSURE_46           12
+#define PID_SUPPORTED_60                   13
+#define PID_Actual_engine_percent_torque_62      14
+#define PID_ENGINE_REFERENCE_TORQUE_63    15
+#define PID_SUPPORTED_80                  16
+#define PID_NOx_reagent_system_85         17
+#define PID_ENGINE_FRICTION_PERCENT_8E    18
+#define PID_SUPPORTED_A0                  19
+
+ #define  PID_Transmission_Actual_Gear_A4  20
+#define	 PID_Commanded_Diesel_Exhaust_Fluid_Dosing_A5  21
+
 
 // Total number of supported PIDs
-#define PID_COUNT 18
+#define PID_COUNT 22
 
 // Enum for PID index access — improves readability
 typedef enum {
     PID_IDX_SUPPORTED_00                = PID_SUPPORTED_00,
     PID_IDX_ENGINE_LOAD_04             = PID_ENGINE_LOAD_04,
     PID_IDX_COOLANT_TEMP_05            = PID_COOLANT_TEMP_05,
+	  PID_IDX_ENGINE_RPM_0C               = PID_ENGINE_RPM_0C ,
     PID_IDX_SUPPORTED_20               = PID_SUPPORTED_20,
-    PID_IDX_FUEL_RAIL_PRESSURE_2D      = PID_FUEL_RAIL_PRESSURE_2D,
+	  PID_IDX_FUEL_RAIL_PRESSURE_22      = PID_FUEL_RAIL_PRESSURE_22 ,
+	  PID_IDX_COMMANDED_EGR_2C           = PID_COMMANDED_EGR_2C ,
+    PID_IDX_EGR_Error_2D              = PID_EGR_Error_2D,
     PID_IDX_FUEL_LEVEL_2F              = PID_FUEL_LEVEL_2F,
+	PID_IDX_DISTANCE_SINCE_DTC_31        =	PID_DISTANCE_SINCE_DTC_31 ,
     PID_IDX_SUPPORTED_40               = PID_SUPPORTED_40,
     PID_IDX_AMBIENT_TEMP_45            = PID_AMBIENT_TEMP_45,
     PID_IDX_ABS_BARO_PRESSURE_46       = PID_ABS_BARO_PRESSURE_46,
     PID_IDX_SUPPORTED_60               = PID_SUPPORTED_60,
-    PID_IDX_COMMANDED_EQUIV_RATIO_62   = PID_COMMANDED_EQUIV_RATIO_62,
+    PID_IDX_Actual_engine_percent_torque_62   = PID_Actual_engine_percent_torque_62,
     PID_IDX_ENGINE_REFERENCE_TORQUE_63 = PID_ENGINE_REFERENCE_TORQUE_63,
     PID_IDX_SUPPORTED_80               = PID_SUPPORTED_80,
-    PID_IDX_THROTTLE_POS_85            = PID_THROTTLE_POS_85,
+    PID_IDX_NOx_reagent_system_85            = PID_NOx_reagent_system_85,
     PID_IDX_ENGINE_FRICTION_PERCENT_8E = PID_ENGINE_FRICTION_PERCENT_8E,
     PID_IDX_SUPPORTED_A0               = PID_SUPPORTED_A0,
-    PID_IDX_ENGINE_PERCENT_TORQUE_A2   = PID_ENGINE_PERCENT_TORQUE_A2,
-    PID_IDX_SUPPORTED_C0               = PID_SUPPORTED_C0
+    
+ PID_IDX_Transmission_Actual_Gear_A4 =   PID_Transmission_Actual_Gear_A4,
+	 PID_IDX_Commanded_Diesel_Exhaust_Fluid_Dosing_A5 =  PID_Commanded_Diesel_Exhaust_Fluid_Dosing_A5,
+   
 } PIDIndex;
 
 // Global PID values array (defined in .c file)

--- a/30_Code/services/Mode_01/src/mode_01.c
+++ b/30_Code/services/Mode_01/src/mode_01.c
@@ -1,0 +1,183 @@
+void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
+    uint8 A = 0, B = 0, C = 0, D = 0;
+    CAN_msg OBDResp;
+    uint8 i;
+	uint8 PID = OBDRequest.data[2]; 
+
+    // List of supported Mode 01 PIDs
+    static const uint8 supported_pids[] = {
+        0x00, 0x04, 0x05, 0x20,
+        0x2D, 0x2F, 0x40,
+        0x45, 0x46, 0x60,
+        0x62, 0x63, 0x80,
+        0x85, 0x8E, 0xA0, 0xA2,
+        0xC0, 0xC3, 0xC4
+    };
+
+    uint8 supported = 0;
+
+    if (OBDRequest.len < 3) return; // Invalid request length
+
+    // Check if requested PID is supported
+    for (i = 0; i < sizeof(supported_pids) / sizeof(supported_pids[0]); i++) {
+        if (supported_pids[i] == PID) {
+            supported = 1;
+            break;
+        }
+    }
+
+    if (!supported) return; // PID not supported
+
+    OBDResp.id = 0x7E8;
+    OBDResp.data[1] = 0x41; // Response to Mode 01
+    OBDResp.data[2] = PID;
+
+    switch (PID) {
+        case 0x00:  // Supported PIDs [01 - 20]
+            A = (PIDValues[PID_IDX_SUPPORTED_00] >> 24) & 0xFF;
+            B = (PIDValues[PID_IDX_SUPPORTED_00] >> 16) & 0xFF;
+            C = (PIDValues[PID_IDX_SUPPORTED_00] >> 8) & 0xFF;
+            D = PIDValues[PID_IDX_SUPPORTED_00] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            OBDResp.data[5] = C;
+            OBDResp.data[6] = D;
+            len = 6;
+            break;
+
+        case 0x04:  // Calculated Engine Load (%)
+            A = (PIDValues[PID_IDX_ENGINE_LOAD_04] * 255) / 100;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x05:  // Engine Coolant Temperature (°C + 40)
+            A = PIDValues[PID_IDX_COOLANT_TEMP_05] + 40;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x20:  // Supported PIDs [21 - 40]
+            A = (PIDValues[PID_IDX_SUPPORTED_20] >> 24) & 0xFF;
+            B = (PIDValues[PID_IDX_SUPPORTED_20] >> 16) & 0xFF;
+            C = (PIDValues[PID_IDX_SUPPORTED_20] >> 8) & 0xFF;
+            D = PIDValues[PID_IDX_SUPPORTED_20] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            OBDResp.data[5] = C;
+            OBDResp.data[6] = D;
+            len = 6;
+            break;
+
+        case 0x2D:  // Fuel Rail Pressure
+            A = ((PIDValues[PID_IDX_FUEL_RAIL_PRESSURE_2D] + 100) * 128) / 100;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x2F:  // Fuel Level Input (%)
+            A = (PIDValues[PID_IDX_FUEL_LEVEL_2F] * 255) / 100;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x40:  // Supported PIDs [41 - 60]
+            A = (PIDValues[PID_IDX_SUPPORTED_40] >> 24) & 0xFF;
+            B = (PIDValues[PID_IDX_SUPPORTED_40] >> 16) & 0xFF;
+            C = (PIDValues[PID_IDX_SUPPORTED_40] >> 8) & 0xFF;
+            D = PIDValues[PID_IDX_SUPPORTED_40] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            OBDResp.data[5] = C;
+            OBDResp.data[6] = D;
+            len = 6;
+            break;
+
+        case 0x45:  // Ambient Air Temperature (%)
+            A = (PIDValues[PID_IDX_AMBIENT_TEMP_45] * 255) / 100;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x46:  // Absolute Barometric Pressure (+40)
+            A = PIDValues[PID_IDX_ABS_BARO_PRESSURE_46] + 40;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x60:  // Supported PIDs [61 - 80]
+            A = (PIDValues[PID_IDX_SUPPORTED_60] >> 24) & 0xFF;
+            B = (PIDValues[PID_IDX_SUPPORTED_60] >> 16) & 0xFF;
+            C = (PIDValues[PID_IDX_SUPPORTED_60] >> 8) & 0xFF;
+            D = PIDValues[PID_IDX_SUPPORTED_60] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            OBDResp.data[5] = C;
+            OBDResp.data[6] = D;
+            len = 6;
+            break;
+
+        case 0x62:  // Commanded Equivalence Ratio (+125)
+            A = PIDValues[PID_IDX_COMMANDED_EQUIV_RATIO_62] + 125;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x63:  // Engine Reference Torque (2 bytes)
+            A = (PIDValues[PID_IDX_ENGINE_REFERENCE_TORQUE_63] >> 8) & 0xFF;
+            B = PIDValues[PID_IDX_ENGINE_REFERENCE_TORQUE_63] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            len = 4;
+            break;
+
+        case 0x80:  // Supported PIDs [81 - A0]
+            A = (PIDValues[PID_IDX_SUPPORTED_80] >> 24) & 0xFF;
+            B = (PIDValues[PID_IDX_SUPPORTED_80] >> 16) & 0xFF;
+            C = (PIDValues[PID_IDX_SUPPORTED_80] >> 8) & 0xFF;
+            D = PIDValues[PID_IDX_SUPPORTED_80] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            OBDResp.data[5] = C;
+            OBDResp.data[6] = D;
+            len = 6;
+            break;
+
+        case 0x85:  // Throttle Position (%)
+            A = (PIDValues[PID_IDX_THROTTLE_POS_85] * 255) / 100;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0x8E:  // Engine Friction Percent Torque (+125)*2
+            A = (uint8)((PIDValues[PID_IDX_ENGINE_FRICTION_PERCENT_8E] + 125) * 2);
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        case 0xA0:  // Supported PIDs [A1 - C0]
+            A = (PIDValues[PID_IDX_SUPPORTED_A0] >> 24) & 0xFF;
+            B = (PIDValues[PID_IDX_SUPPORTED_A0] >> 16) & 0xFF;
+            C = (PIDValues[PID_IDX_SUPPORTED_A0] >> 8) & 0xFF;
+            D = PIDValues[PID_IDX_SUPPORTED_A0] & 0xFF;
+            OBDResp.data[3] = A;
+            OBDResp.data[4] = B;
+            OBDResp.data[5] = C;
+            OBDResp.data[6] = D;
+            len = 6;
+            break;
+
+        case 0xA2:  // Engine Percent Torque (scaled)
+            A = (PIDValues[PID_IDX_ENGINE_PERCENT_TORQUE_A2] * 128) / 100;
+            OBDResp.data[3] = A;
+            len = 3;
+            break;
+
+        default:
+            return; // Do nothing if PID is not matched
+    }
+
+    OBDResp.data[0] = len;  // Set response length
+    OBDResp.len = len + 1;
+    can_tp_transmit(CANCTRL1, OBDResp, OBDResp.len);  // Transmit the response
+}

--- a/30_Code/services/Mode_01/src/mode_01.c
+++ b/30_Code/services/Mode_01/src/mode_01.c
@@ -1,7 +1,9 @@
-void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
+#include "mode_01.h"
+void mode_01_req_handler(can_msg_t OBDRequest) {
     uint8 A = 0, B = 0, C = 0, D = 0;
-    CAN_msg OBDResp;
+   can_msg_t OBDResp;
     uint8 i;
+	uint8 len;
 	uint8 PID = OBDRequest.data[2]; 
 
     // List of supported Mode 01 PIDs
@@ -10,8 +12,8 @@ void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
         0x2D, 0x2F, 0x40,
         0x45, 0x46, 0x60,
         0x62, 0x63, 0x80,
-        0x85, 0x8E, 0xA0, 0xA2,
-        0xC0, 0xC3, 0xC4
+        0x85, 0x8E, 0xA0, 0xA4,0xA5,
+        0x0C,0x22,0x2C,0x31
     };
 
     uint8 supported = 0;
@@ -29,8 +31,8 @@ void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
     if (!supported) return; // PID not supported
 
     OBDResp.id = 0x7E8;
-    OBDResp.data[1] = 0x41; // Response to Mode 01
-    OBDResp.data[2] = PID;
+    OBDResp.data[0] = 0x41; // Response to Mode 01
+    OBDResp.data[1] = PID;
 
     switch (PID) {
         case 0x00:  // Supported PIDs [01 - 20]
@@ -38,47 +40,74 @@ void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
             B = (PIDValues[PID_IDX_SUPPORTED_00] >> 16) & 0xFF;
             C = (PIDValues[PID_IDX_SUPPORTED_00] >> 8) & 0xFF;
             D = PIDValues[PID_IDX_SUPPORTED_00] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
-            OBDResp.data[5] = C;
-            OBDResp.data[6] = D;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            OBDResp.data[4] = C;
+            OBDResp.data[5] = D;
             len = 6;
             break;
 
         case 0x04:  // Calculated Engine Load (%)
             A = (PIDValues[PID_IDX_ENGINE_LOAD_04] * 255) / 100;
-            OBDResp.data[3] = A;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
-        case 0x05:  // Engine Coolant Temperature (°C + 40)
+        case 0x05:  // Engine Coolant Temperature 
             A = PIDValues[PID_IDX_COOLANT_TEMP_05] + 40;
-            OBDResp.data[3] = A;
+            OBDResp.data[2] = A;
             len = 3;
             break;
-
+				
+       case 0x0C:  // Engine RPM
+            // Formula: ((A * 256) + B) / 4
+            //uint16 rpm = PIDValues[PID_IDX_ENGINE_RPM_0C];  // rpm is a uint16_t
+            A = (PIDValues[PID_IDX_ENGINE_RPM_0C] >> 8) & 0xFF;
+            B = PIDValues[PID_IDX_ENGINE_RPM_0C] & 0xFF;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            len = 4;
+            break;
+				
         case 0x20:  // Supported PIDs [21 - 40]
             A = (PIDValues[PID_IDX_SUPPORTED_20] >> 24) & 0xFF;
             B = (PIDValues[PID_IDX_SUPPORTED_20] >> 16) & 0xFF;
             C = (PIDValues[PID_IDX_SUPPORTED_20] >> 8) & 0xFF;
             D = PIDValues[PID_IDX_SUPPORTED_20] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
-            OBDResp.data[5] = C;
-            OBDResp.data[6] = D;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            OBDResp.data[4] = C;
+            OBDResp.data[5] = D;
             len = 6;
             break;
+				
+        case 0x2C:  // Commanded EGR (%)
+            // Formula: A * 100 / 255
+            A = (PIDValues[PID_IDX_COMMANDED_EGR_2C] * 255) / 100;
+            OBDResp.data[2] = A;
+            len = 3;
+            break;
 
-        case 0x2D:  // Fuel Rail Pressure
-            A = ((PIDValues[PID_IDX_FUEL_RAIL_PRESSURE_2D] + 100) * 128) / 100;
-            OBDResp.data[3] = A;
+         case 0x2D:  // EGR Error
+            A = ((PIDValues[PID_IDX_EGR_Error_2D] + 100) * 128) / 100;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
         case 0x2F:  // Fuel Level Input (%)
             A = (PIDValues[PID_IDX_FUEL_LEVEL_2F] * 255) / 100;
-            OBDResp.data[3] = A;
+            OBDResp.data[2] = A;
             len = 3;
+            break;
+        
+	case 0x31:  // Distance since DTCs cleared (km)
+            // Formula: (A * 256) + B
+            //distance = PIDValues[PID_IDX_DISTANCE_SINCE_DTC_31];  // in km
+            A = (PIDValues[PID_IDX_DISTANCE_SINCE_DTC_31] >> 8) & 0xFF;
+            B = PIDValues[PID_IDX_DISTANCE_SINCE_DTC_31] & 0xFF;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            len = 4;
             break;
 
         case 0x40:  // Supported PIDs [41 - 60]
@@ -86,22 +115,22 @@ void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
             B = (PIDValues[PID_IDX_SUPPORTED_40] >> 16) & 0xFF;
             C = (PIDValues[PID_IDX_SUPPORTED_40] >> 8) & 0xFF;
             D = PIDValues[PID_IDX_SUPPORTED_40] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
-            OBDResp.data[5] = C;
-            OBDResp.data[6] = D;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            OBDResp.data[4] = C;
+            OBDResp.data[5] = D;
             len = 6;
             break;
 
-        case 0x45:  // Ambient Air Temperature (%)
+        case 0x45:  // Relative throttle position (%)
             A = (PIDValues[PID_IDX_AMBIENT_TEMP_45] * 255) / 100;
-            OBDResp.data[3] = A;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
-        case 0x46:  // Absolute Barometric Pressure (+40)
+        case 0x46:  //Ambient air temperature  (+40)
             A = PIDValues[PID_IDX_ABS_BARO_PRESSURE_46] + 40;
-            OBDResp.data[3] = A;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
@@ -110,24 +139,24 @@ void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
             B = (PIDValues[PID_IDX_SUPPORTED_60] >> 16) & 0xFF;
             C = (PIDValues[PID_IDX_SUPPORTED_60] >> 8) & 0xFF;
             D = PIDValues[PID_IDX_SUPPORTED_60] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
-            OBDResp.data[5] = C;
-            OBDResp.data[6] = D;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            OBDResp.data[4] = C;
+            OBDResp.data[5] = D;
             len = 6;
             break;
 
-        case 0x62:  // Commanded Equivalence Ratio (+125)
-            A = PIDValues[PID_IDX_COMMANDED_EQUIV_RATIO_62] + 125;
-            OBDResp.data[3] = A;
+        case 0x62:  // Actual engine - percent torque (+125)
+            A = PIDValues[PID_IDX_Actual_engine_percent_torque_62] + 125;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
         case 0x63:  // Engine Reference Torque (2 bytes)
             A = (PIDValues[PID_IDX_ENGINE_REFERENCE_TORQUE_63] >> 8) & 0xFF;
             B = PIDValues[PID_IDX_ENGINE_REFERENCE_TORQUE_63] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
             len = 4;
             break;
 
@@ -136,48 +165,79 @@ void Mode_01_Req_Handler(CanMsg_t OBDRequest) {
             B = (PIDValues[PID_IDX_SUPPORTED_80] >> 16) & 0xFF;
             C = (PIDValues[PID_IDX_SUPPORTED_80] >> 8) & 0xFF;
             D = PIDValues[PID_IDX_SUPPORTED_80] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
-            OBDResp.data[5] = C;
-            OBDResp.data[6] = D;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            OBDResp.data[4] = C;
+            OBDResp.data[5] = D;
             len = 6;
             break;
 
-        case 0x85:  // Throttle Position (%)
-            A = (PIDValues[PID_IDX_THROTTLE_POS_85] * 255) / 100;
-            OBDResp.data[3] = A;
+        case 0x85:  // NOx reagent system
+            A = (PIDValues[PID_IDX_NOx_reagent_system_85] * 255) / 100;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
-        case 0x8E:  // Engine Friction Percent Torque (+125)*2
-            A = (uint8)((PIDValues[PID_IDX_ENGINE_FRICTION_PERCENT_8E] + 125) * 2);
-            OBDResp.data[3] = A;
+        case 0x8E:  // Engine Friction Percent Torque 
+            A = (PIDValues[PID_IDX_ENGINE_FRICTION_PERCENT_8E] + 125) ;
+            OBDResp.data[2] = A;
             len = 3;
             break;
 
-        case 0xA0:  // Supported PIDs [A1 - C0]
+        case 0xA0: 
             A = (PIDValues[PID_IDX_SUPPORTED_A0] >> 24) & 0xFF;
             B = (PIDValues[PID_IDX_SUPPORTED_A0] >> 16) & 0xFF;
             C = (PIDValues[PID_IDX_SUPPORTED_A0] >> 8) & 0xFF;
             D = PIDValues[PID_IDX_SUPPORTED_A0] & 0xFF;
-            OBDResp.data[3] = A;
-            OBDResp.data[4] = B;
-            OBDResp.data[5] = C;
-            OBDResp.data[6] = D;
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            OBDResp.data[4] = C;
+            OBDResp.data[5] = D;
             len = 6;
             break;
+				
+				
+	case 0xA4:  
+       {
+             float value = PIDValues[PID_IDX_Transmission_Actual_Gear_A4];  
+             uint16 raw = (uint16)(value * 1000);  
 
-        case 0xA2:  // Engine Percent Torque (scaled)
-            A = (PIDValues[PID_IDX_ENGINE_PERCENT_TORQUE_A2] * 128) / 100;
-            OBDResp.data[3] = A;
-            len = 3;
+             A = (raw >> 8) & 0xFF;
+             B = raw & 0xFF;
+
+            OBDResp.data[2] = A;
+            OBDResp.data[3] = B;
+            len = 4;
             break;
+      }
+
+
+       case 0xA5:  
+      {
+             float value = PIDValues[PID_IDX_Commanded_Diesel_Exhaust_Fluid_Dosing_A5]; 
+             B= (uint8 )(value * 2); 
+
+             OBDResp.data[2] = B;
+             len = 3;
+             break;
+       }
+ 
 
         default:
             return; // Do nothing if PID is not matched
     }
+		if(len<6)
+		{
+			for (i = len; i < 7; i++)
+			{  // padding up to index 6
+                            OBDResp.data[i] = 0;
+                        }
+                       OBDResp.data[7] = 0;         // Ensure full 8-byte frame
+		}
+		
 
-    OBDResp.data[0] = len;  // Set response length
-    OBDResp.len = len + 1;
-    can_tp_transmit(CANCTRL1, OBDResp, OBDResp.len);  // Transmit the response
+
+    //OBDResp.data[0] = len;  // Set response length
+    OBDResp.len = len;
+    can_tp_transmit(can_ctrl_1, OBDResp, OBDResp.len);  // Transmit the response
 }

--- a/30_Code/services/Mode_01/src/mode_01.c
+++ b/30_Code/services/Mode_01/src/mode_01.c
@@ -13,7 +13,7 @@ void mode_01_req_handler(can_msg_t OBDRequest) {
         0x45, 0x46, 0x60,
         0x62, 0x63, 0x80,
         0x85, 0x8E, 0xA0, 0xA4,0xA5,
-        0x0C,0x22,0x2C,0x31
+        0x0C,0x22,0x31
     };
 
     uint8 supported = 0;
@@ -79,13 +79,6 @@ void mode_01_req_handler(can_msg_t OBDRequest) {
             OBDResp.data[4] = C;
             OBDResp.data[5] = D;
             len = 6;
-            break;
-				
-        case 0x2C:  // Commanded EGR (%)
-            // Formula: A * 100 / 255
-            A = (PIDValues[PID_IDX_COMMANDED_EGR_2C] * 255) / 100;
-            OBDResp.data[2] = A;
-            len = 3;
             break;
 
          case 0x2D:  // EGR Error

--- a/30_Code/services/Mode_01/src/obd_PIDs.c
+++ b/30_Code/services/Mode_01/src/obd_PIDs.c
@@ -1,0 +1,33 @@
+#include "Types.h"
+#include "obd_PIDs.h"
+#include "PID_values.h"
+
+// Global array of PID values (all PIDs that are part of Mode 01)
+uint32 PIDValues[PID_COUNT] = {
+    PID_VAL_SUPPORTED_00,            // PID_SUPPORTED_00 (supports 0x04 and 0x05)
+    PID_VAL_ENGINE_LOAD_04,          // PID_ENGINE_LOAD_04
+    PID_VAL_COOLANT_TEMP_05,         // PID_COOLANT_TEMP_05
+
+    PID_VAL_SUPPORTED_20,            // PID_SUPPORTED_20 (supports 0x2D and 0x2F)
+    PID_VAL_FUEL_RAIL_PRESSURE_2D,   // PID_FUEL_RAIL_PRESSURE_2D
+    PID_VAL_FUEL_LEVEL_2F,           // PID_FUEL_LEVEL_2F
+
+    PID_VAL_SUPPORTED_40,            // PID_SUPPORTED_40 (supports 0x45 and 0x46)
+    PID_VAL_AMBIENT_TEMP_45,         // PID_AMBIENT_TEMP_45
+    PID_VAL_ABS_BARO_PRESSURE_46,    // PID_ABS_BARO_PRESSURE_46
+
+    PID_VAL_SUPPORTED_60,            // PID_SUPPORTED_60 (supports 0x62 and 0x63)
+    PID_VAL_COMMANDED_EQUIV_RATIO_62,// PID_COMMANDED_EQUIV_RATIO_62
+    PID_VAL_ENGINE_REFERENCE_TORQUE_63, // PID_ENGINE_REFERENCE_TORQUE_63
+
+    PID_VAL_SUPPORTED_80,            // PID_SUPPORTED_80 (supports 0x80, 0x85, and 0x8E)
+    PID_VAL_THROTTLE_POS_85,         // PID_THROTTLE_POS_85
+    PID_VAL_ENGINE_FRICTION_PERCENT_8E, // PID_ENGINE_FRICTION_PERCENT_8E
+
+    PID_VAL_SUPPORTED_A0,            // PID_SUPPORTED_A0 (supports 0xA0 and 0xA2)
+    PID_VAL_ENGINE_PERCENT_TORQUE_A2, // PID_ENGINE_PERCENT_TORQUE_A2
+
+    PID_VAL_SUPPORTED_C0             // PID_SUPPORTED_C0 (no specific PIDs supported)
+};
+
+//#define PID_COUNT (sizeof(PIDValues) / sizeof(PIDValues[0])) // Number of PIDs

--- a/30_Code/services/Mode_01/src/obd_PIDs.c
+++ b/30_Code/services/Mode_01/src/obd_PIDs.c
@@ -1,4 +1,3 @@
-#include "Types.h"
 #include "obd_PIDs.h"
 #include "PID_values.h"
 
@@ -8,26 +7,30 @@ uint32 PIDValues[PID_COUNT] = {
     PID_VAL_ENGINE_LOAD_04,          // PID_ENGINE_LOAD_04
     PID_VAL_COOLANT_TEMP_05,         // PID_COOLANT_TEMP_05
 
+	PID_VAL_ENGINE_RPM_0C,  
     PID_VAL_SUPPORTED_20,            // PID_SUPPORTED_20 (supports 0x2D and 0x2F)
-    PID_VAL_FUEL_RAIL_PRESSURE_2D,   // PID_FUEL_RAIL_PRESSURE_2D
+	PID_VAL_FUEL_RAIL_PRESSURE_22,
+	PID_VAL_COMMANDED_EGR_2C,
+    PID_VAL_EGR_Error_2D,   // PID_FUEL_RAIL_PRESSURE_2D
     PID_VAL_FUEL_LEVEL_2F,           // PID_FUEL_LEVEL_2F
 
+	PID_VAL_DISTANCE_SINCE_DTC_31,
     PID_VAL_SUPPORTED_40,            // PID_SUPPORTED_40 (supports 0x45 and 0x46)
     PID_VAL_AMBIENT_TEMP_45,         // PID_AMBIENT_TEMP_45
     PID_VAL_ABS_BARO_PRESSURE_46,    // PID_ABS_BARO_PRESSURE_46
 
     PID_VAL_SUPPORTED_60,            // PID_SUPPORTED_60 (supports 0x62 and 0x63)
-    PID_VAL_COMMANDED_EQUIV_RATIO_62,// PID_COMMANDED_EQUIV_RATIO_62
+    PID_VAL_Actual_engine_percent_torque_62,// PID_COMMANDED_EQUIV_RATIO_62
     PID_VAL_ENGINE_REFERENCE_TORQUE_63, // PID_ENGINE_REFERENCE_TORQUE_63
 
-    PID_VAL_SUPPORTED_80,            // PID_SUPPORTED_80 (supports 0x80, 0x85, and 0x8E)
-    PID_VAL_THROTTLE_POS_85,         // PID_THROTTLE_POS_85
+    PID_VAL_SUPPORTED_80,            // PID_SUPPORTED_80 (supports 0x85, and 0x8E)
+    PID_VAL_NOx_reagent_system_85,         // PID_THROTTLE_POS_85
     PID_VAL_ENGINE_FRICTION_PERCENT_8E, // PID_ENGINE_FRICTION_PERCENT_8E
 
-    PID_VAL_SUPPORTED_A0,            // PID_SUPPORTED_A0 (supports 0xA0 and 0xA2)
-    PID_VAL_ENGINE_PERCENT_TORQUE_A2, // PID_ENGINE_PERCENT_TORQUE_A2
-
-    PID_VAL_SUPPORTED_C0             // PID_SUPPORTED_C0 (no specific PIDs supported)
+    PID_VAL_SUPPORTED_A0,            // PID_SUPPORTED_A0 (supports 0xA4 and 0xA5)
+    PID_VAL_Transmission_Actual_Gear_A4,
+    PID_VAL_Commanded_Diesel_Exhaust_Fluid_Dosing_A5,
+    
 };
 
-//#define PID_COUNT (sizeof(PIDValues) / sizeof(PIDValues[0])) // Number of PIDs
+//#define PID_COUNT (sizeof(PIDValues) / sizeof(PIDValues[0])) // Number of PID


### PR DESCRIPTION
This pull request includes the implementation for Mode 01 of the OBD-II stack. The following files have been created and added:

- mode_01.h — Header file declaring Mode 01 related functions and definitions.
- mode_01.c — Source file implementing Mode 01 request handling.
- obd_PIDs.h — Contains PID definitions specific to Mode 01.
- obd_PIDs.c — Source file for PID-related logic and handling.
- PID_values.h — Header for storing or accessing PID data values.